### PR TITLE
Add storage map visualization

### DIFF
--- a/src/FileStrider.Infrastructure/Resources/Strings.es.resx
+++ b/src/FileStrider.Infrastructure/Resources/Strings.es.resx
@@ -100,6 +100,9 @@
   <data name="LargestFolders" xml:space="preserve">
     <value>📁 Carpetas Más Grandes</value>
   </data>
+  <data name="StorageMap" xml:space="preserve">
+    <value>🗺️ Mapa de almacenamiento</value>
+  </data>
   <data name="Cancel" xml:space="preserve">
     <value>❌ Cancelar</value>
   </data>

--- a/src/FileStrider.Infrastructure/Resources/Strings.fr.resx
+++ b/src/FileStrider.Infrastructure/Resources/Strings.fr.resx
@@ -100,6 +100,9 @@
   <data name="LargestFolders" xml:space="preserve">
     <value>📁 Plus Gros Dossiers</value>
   </data>
+  <data name="StorageMap" xml:space="preserve">
+    <value>🗺️ Carte de stockage</value>
+  </data>
   <data name="Cancel" xml:space="preserve">
     <value>❌ Annuler</value>
   </data>

--- a/src/FileStrider.Infrastructure/Resources/Strings.resx
+++ b/src/FileStrider.Infrastructure/Resources/Strings.resx
@@ -100,6 +100,9 @@
   <data name="LargestFolders" xml:space="preserve">
     <value>📁 Largest Folders</value>
   </data>
+  <data name="StorageMap" xml:space="preserve">
+    <value>🗺️ Storage Map</value>
+  </data>
   <data name="Cancel" xml:space="preserve">
     <value>❌ Cancel</value>
   </data>

--- a/src/FileStrider.Infrastructure/Resources/Strings.sv.resx
+++ b/src/FileStrider.Infrastructure/Resources/Strings.sv.resx
@@ -100,6 +100,9 @@
   <data name="LargestFolders" xml:space="preserve">
     <value>📁 Största mapparna</value>
   </data>
+  <data name="StorageMap" xml:space="preserve">
+    <value>🗺️ Lagringskarta</value>
+  </data>
   <data name="Cancel" xml:space="preserve">
     <value>❌ Avbryt</value>
   </data>

--- a/src/FileStrider.MauiApp/ViewModels/MainWindowViewModel.cs
+++ b/src/FileStrider.MauiApp/ViewModels/MainWindowViewModel.cs
@@ -455,10 +455,6 @@ public partial class MainWindowViewModel : ObservableObject
         else
         {
             var totalSize = TopFiles.Sum(file => Math.Max(file.Size, 1L));
-            if (totalSize == 0)
-            {
-                return;
-            }
 
             for (int i = 0; i < TopFiles.Count; i++)
             {

--- a/src/FileStrider.MauiApp/ViewModels/StorageMapSliceViewModel.cs
+++ b/src/FileStrider.MauiApp/ViewModels/StorageMapSliceViewModel.cs
@@ -1,0 +1,33 @@
+using System.Globalization;
+using Avalonia.Media;
+
+namespace FileStrider.MauiApp.ViewModels;
+
+public class StorageMapSliceViewModel
+{
+    public StorageMapSliceViewModel(string name, string fullPath, long size, double share, string displaySize, IBrush brush)
+    {
+        Name = name;
+        FullPath = fullPath;
+        Size = size;
+        Share = share;
+        DisplaySize = displaySize;
+        Brush = brush;
+    }
+
+    public string Name { get; }
+
+    public string FullPath { get; }
+
+    public long Size { get; }
+
+    public double Share { get; }
+
+    public string DisplaySize { get; }
+
+    public IBrush Brush { get; }
+
+    public string ShareDisplay => Share.ToString("P1", CultureInfo.CurrentCulture);
+
+    public string Tooltip => $"{FullPath}\n{DisplaySize} • {ShareDisplay}";
+}

--- a/src/FileStrider.MauiApp/Views/Controls/TreemapPanel.cs
+++ b/src/FileStrider.MauiApp/Views/Controls/TreemapPanel.cs
@@ -1,0 +1,89 @@
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Media;
+
+namespace FileStrider.MauiApp.Views.Controls;
+
+public class TreemapPanel : Panel
+{
+    public static readonly AttachedProperty<double> WeightProperty =
+        AvaloniaProperty.RegisterAttached<TreemapPanel, Control, double>("Weight", 1d);
+
+    public static double GetWeight(Control control) => control.GetValue(WeightProperty);
+
+    public static void SetWeight(Control control, double value) => control.SetValue(WeightProperty, value);
+
+    protected override Size MeasureOverride(Size availableSize)
+    {
+        foreach (var child in Children)
+        {
+            child.Measure(availableSize);
+        }
+
+        var width = double.IsInfinity(availableSize.Width) ? 0 : availableSize.Width;
+        var height = double.IsInfinity(availableSize.Height) ? 0 : availableSize.Height;
+        return new Size(width, height);
+    }
+
+    protected override Size ArrangeOverride(Size finalSize)
+    {
+        if (Children.Count == 0 || finalSize.Width <= 0 || finalSize.Height <= 0)
+        {
+            return finalSize;
+        }
+
+        var totalWeight = Children.Sum(child => Math.Max(child.GetValue(WeightProperty), 0.0));
+        if (totalWeight <= 0)
+        {
+            foreach (var child in Children)
+            {
+                child.Arrange(new Rect(0, 0, 0, 0));
+            }
+            return finalSize;
+        }
+
+        double remainingWidth = finalSize.Width;
+        double remainingHeight = finalSize.Height;
+        double offsetX = 0;
+        double offsetY = 0;
+        double accumulatedWeight = totalWeight;
+        bool horizontal = finalSize.Width >= finalSize.Height;
+
+        foreach (var child in Children)
+        {
+            var weight = Math.Max(child.GetValue(WeightProperty), 0.0);
+            if (weight <= 0)
+            {
+                child.Arrange(new Rect(offsetX, offsetY, 0, 0));
+                continue;
+            }
+
+            var fraction = weight / accumulatedWeight;
+            if (horizontal)
+            {
+                var childWidth = remainingWidth * fraction;
+                child.Arrange(new Rect(offsetX, offsetY, childWidth, remainingHeight));
+                offsetX += childWidth;
+                remainingWidth -= childWidth;
+            }
+            else
+            {
+                var childHeight = remainingHeight * fraction;
+                child.Arrange(new Rect(offsetX, offsetY, remainingWidth, childHeight));
+                offsetY += childHeight;
+                remainingHeight -= childHeight;
+            }
+
+            accumulatedWeight -= weight;
+            if (accumulatedWeight <= 0)
+            {
+                break;
+            }
+
+            horizontal = remainingWidth >= remainingHeight;
+        }
+
+        return finalSize;
+    }
+}

--- a/src/FileStrider.MauiApp/Views/Controls/TreemapPanel.cs
+++ b/src/FileStrider.MauiApp/Views/Controls/TreemapPanel.cs
@@ -81,7 +81,7 @@ public class TreemapPanel : Panel
                 break;
             }
 
-            horizontal = remainingWidth >= remainingHeight;
+            // horizontal = remainingWidth >= remainingHeight; // Removed to keep direction constant per level
         }
 
         return finalSize;

--- a/src/FileStrider.MauiApp/Views/MainWindow.axaml
+++ b/src/FileStrider.MauiApp/Views/MainWindow.axaml
@@ -2,6 +2,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:FileStrider.MauiApp.ViewModels"
         xmlns:models="using:FileStrider.Core.Models"
+        xmlns:controls="using:FileStrider.MauiApp.Views.Controls"
         x:Class="FileStrider.MauiApp.Views.MainWindow"
         x:DataType="vm:MainWindowViewModel"
         Title="{Binding Title}"
@@ -121,110 +122,188 @@
 
         <!-- Results Area -->
         <Grid Grid.Row="2">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="*"/>
-            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="2*"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
 
-            <!-- Files -->
-            <Border Grid.Column="0" 
-                    BorderBrush="LightGray" 
-                    BorderThickness="1" 
-                    CornerRadius="5" 
-                    Margin="0,0,5,0">
+            <Grid Grid.Row="0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+
+                <!-- Files -->
+                <Border Grid.Column="0"
+                        BorderBrush="LightGray"
+                        BorderThickness="1"
+                        CornerRadius="5"
+                        Margin="0,0,5,0">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+
+                        <TextBlock Grid.Row="0"
+                                   Text="{Binding LargestFilesLabel}"
+                                   FontSize="16"
+                                   FontWeight="Bold"
+                                   Margin="10,10,10,5"/>
+
+                        <ListBox Grid.Row="1"
+                                 ItemsSource="{Binding TopFiles}"
+                                 Margin="5">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate x:DataType="models:FileItem">
+                                    <Grid Margin="5"
+                                          ToolTip.Tip="{Binding FullPath}"
+                                          DoubleTapped="FileItem_DoubleTapped">
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                        </Grid.RowDefinitions>
+
+                                        <TextBlock Grid.Row="0"
+                                                   Text="{Binding Name}"
+                                                   FontWeight="Bold"
+                                                   TextTrimming="CharacterEllipsis"/>
+                                        <TextBlock Grid.Row="1"
+                                                   FontSize="10"
+                                                   Foreground="Gray">
+                                            <Run Text="Size: "/>
+                                            <Run Text="{Binding Size, StringFormat='N0'}"/>
+                                            <Run Text=" bytes | Modified: "/>
+                                            <Run Text="{Binding LastModified, StringFormat='yyyy-MM-dd HH:mm'}"/>
+                                        </TextBlock>
+                                    </Grid>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+                    </Grid>
+                </Border>
+
+                <!-- Folders -->
+                <Border Grid.Column="1"
+                        BorderBrush="LightGray"
+                        BorderThickness="1"
+                        CornerRadius="5"
+                        Margin="5,0,0,0">
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="*"/>
+                        </Grid.RowDefinitions>
+
+                        <TextBlock Grid.Row="0"
+                                   Text="{Binding LargestFoldersLabel}"
+                                   FontSize="16"
+                                   FontWeight="Bold"
+                                   Margin="10,10,10,5"/>
+
+                        <ListBox Grid.Row="1"
+                                 ItemsSource="{Binding TopFolders}"
+                                 Margin="5">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate x:DataType="models:FolderItem">
+                                    <Grid Margin="5"
+                                          ToolTip.Tip="{Binding FullPath}"
+                                          DoubleTapped="FolderItem_DoubleTapped">
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto"/>
+                                            <RowDefinition Height="Auto"/>
+                                        </Grid.RowDefinitions>
+
+                                        <TextBlock Grid.Row="0"
+                                                   Text="{Binding Name}"
+                                                   FontWeight="Bold"
+                                                   TextTrimming="CharacterEllipsis"/>
+                                        <TextBlock Grid.Row="1"
+                                                   FontSize="10"
+                                                   Foreground="Gray">
+                                            <Run Text="Size: "/>
+                                            <Run Text="{Binding RecursiveSize, StringFormat='N0'}"/>
+                                            <Run Text=" bytes | Items: "/>
+                                            <Run Text="{Binding ItemCount, StringFormat='N0'}"/>
+                                            <Run Text=" | Modified: "/>
+                                            <Run Text="{Binding LastModified, StringFormat='yyyy-MM-dd HH:mm'}"/>
+                                        </TextBlock>
+                                    </Grid>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+                    </Grid>
+                </Border>
+            </Grid>
+
+            <!-- Storage Map -->
+            <Border Grid.Row="1"
+                    BorderBrush="LightGray"
+                    BorderThickness="1"
+                    CornerRadius="5"
+                    Margin="0,10,0,0"
+                    Padding="10"
+                    MinHeight="220">
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
-                    
-                    <TextBlock Grid.Row="0" 
-                               Text="{Binding LargestFilesLabel}" 
-                               FontSize="16" 
-                               FontWeight="Bold" 
-                               Margin="10,10,10,5"/>
-                    
-                    <ListBox Grid.Row="1" 
-                             ItemsSource="{Binding TopFiles}"
-                             Margin="5">
-                        <ListBox.ItemTemplate>
-                            <DataTemplate x:DataType="models:FileItem">
-                                <Grid Margin="5" 
-                                      ToolTip.Tip="{Binding FullPath}"
-                                      DoubleTapped="FileItem_DoubleTapped">
-                                    <Grid.RowDefinitions>
-                                        <RowDefinition Height="Auto"/>
-                                        <RowDefinition Height="Auto"/>
-                                    </Grid.RowDefinitions>
-                                    
-                                    <TextBlock Grid.Row="0" 
-                                               Text="{Binding Name}" 
-                                               FontWeight="Bold"
-                                               TextTrimming="CharacterEllipsis"/>
-                                    <TextBlock Grid.Row="1" 
-                                               FontSize="10"
-                                               Foreground="Gray">
-                                        <Run Text="Size: "/>
-                                        <Run Text="{Binding Size, StringFormat='N0'}"/>
-                                        <Run Text=" bytes | Modified: "/>
-                                        <Run Text="{Binding LastModified, StringFormat='yyyy-MM-dd HH:mm'}"/>
-                                    </TextBlock>
-                                </Grid>
-                            </DataTemplate>
-                        </ListBox.ItemTemplate>
-                    </ListBox>
-                </Grid>
-            </Border>
 
-            <!-- Folders -->
-            <Border Grid.Column="1" 
-                    BorderBrush="LightGray" 
-                    BorderThickness="1" 
-                    CornerRadius="5" 
-                    Margin="5,0,0,0">
-                <Grid>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="*"/>
-                    </Grid.RowDefinitions>
-                    
-                    <TextBlock Grid.Row="0" 
-                               Text="{Binding LargestFoldersLabel}" 
-                               FontSize="16" 
-                               FontWeight="Bold" 
-                               Margin="10,10,10,5"/>
-                    
-                    <ListBox Grid.Row="1" 
-                             ItemsSource="{Binding TopFolders}"
-                             Margin="5">
-                        <ListBox.ItemTemplate>
-                            <DataTemplate x:DataType="models:FolderItem">
-                                <Grid Margin="5" 
-                                      ToolTip.Tip="{Binding FullPath}"
-                                      DoubleTapped="FolderItem_DoubleTapped">
-                                    <Grid.RowDefinitions>
-                                        <RowDefinition Height="Auto"/>
-                                        <RowDefinition Height="Auto"/>
-                                    </Grid.RowDefinitions>
-                                    
-                                    <TextBlock Grid.Row="0" 
-                                               Text="{Binding Name}" 
-                                               FontWeight="Bold"
-                                               TextTrimming="CharacterEllipsis"/>
-                                    <TextBlock Grid.Row="1" 
-                                               FontSize="10"
-                                               Foreground="Gray">
-                                        <Run Text="Size: "/>
-                                        <Run Text="{Binding RecursiveSize, StringFormat='N0'}"/>
-                                        <Run Text=" bytes | Items: "/>
-                                        <Run Text="{Binding ItemCount, StringFormat='N0'}"/>
-                                        <Run Text=" | Modified: "/>
-                                        <Run Text="{Binding LastModified, StringFormat='yyyy-MM-dd HH:mm'}"/>
-                                    </TextBlock>
-                                </Grid>
+                    <TextBlock Grid.Row="0"
+                               Text="{Binding StorageMapLabel}"
+                               FontSize="16"
+                               FontWeight="Bold"
+                               Margin="0,0,0,10"/>
+
+                    <ItemsControl Grid.Row="1"
+                                  ItemsSource="{Binding StorageMapSlices}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <controls:TreemapPanel/>
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemContainerStyle>
+                            <Style Selector="ContentPresenter">
+                                <Setter Property="controls:TreemapPanel.Weight" Value="{Binding Size}"/>
+                            </Style>
+                        </ItemsControl.ItemContainerStyle>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate x:DataType="vm:StorageMapSliceViewModel">
+                                <Border Background="{Binding Brush}"
+                                        BorderBrush="#40FFFFFF"
+                                        BorderThickness="1"
+                                        CornerRadius="6"
+                                        Padding="8"
+                                        Margin="2"
+                                        ToolTip.Tip="{Binding Tooltip}"
+                                        DoubleTapped="StorageMapItem_DoubleTapped">
+                                    <StackPanel>
+                                        <TextBlock Text="{Binding Name}"
+                                                   FontWeight="Bold"
+                                                   Foreground="White"
+                                                   TextTrimming="CharacterEllipsis"/>
+                                        <TextBlock Text="{Binding DisplaySize}"
+                                                   FontSize="11"
+                                                   Foreground="White"
+                                                   Opacity="0.9"/>
+                                        <TextBlock Text="{Binding ShareDisplay}"
+                                                   FontSize="10"
+                                                   Foreground="White"
+                                                   Opacity="0.8"/>
+                                    </StackPanel>
+                                </Border>
                             </DataTemplate>
-                        </ListBox.ItemTemplate>
-                    </ListBox>
+                        </ItemsControl.ItemTemplate>
+                        <ItemsControl.Template>
+                            <ControlTemplate>
+                                <ScrollViewer HorizontalScrollBarVisibility="Disabled"
+                                              VerticalScrollBarVisibility="Disabled">
+                                    <ItemsPresenter/>
+                                </ScrollViewer>
+                            </ControlTemplate>
+                        </ItemsControl.Template>
+                    </ItemsControl>
                 </Grid>
             </Border>
         </Grid>

--- a/src/FileStrider.MauiApp/Views/MainWindow.axaml.cs
+++ b/src/FileStrider.MauiApp/Views/MainWindow.axaml.cs
@@ -34,4 +34,15 @@ public partial class MainWindow : Window
             }
         }
     }
+
+    private async void StorageMapItem_DoubleTapped(object? sender, TappedEventArgs e)
+    {
+        if (sender is Border border && border.DataContext is StorageMapSliceViewModel slice)
+        {
+            if (DataContext is MainWindowViewModel viewModel)
+            {
+                await viewModel.OpenStorageMapItemCommand.ExecuteAsync(slice);
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add a treemap-based storage map to the main window alongside the existing largest files and folders lists
- compute localized storage map slices in the view-model and support opening their locations on double-tap
- provide "Storage Map" strings for all supported languages and add a reusable TreemapPanel layout control

## Testing
- dotnet test *(fails: dotnet is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca85ff183c832c898ac341121651a4